### PR TITLE
animation: invert animationIsPlaying check in play

### DIFF
--- a/components/animation/index.js
+++ b/components/animation/index.js
@@ -112,7 +112,7 @@ AFRAME.registerComponent('animation', {
     var data = this.data;
     var self = this;
 
-    if (!this.animation || !this.animationIsPlaying) { return; }
+    if (!this.animation || this.animationIsPlaying) { return; }
 
     // Delay.
     if (data.delay) {


### PR DESCRIPTION
This logic is causing me some issues. It seems that the logic should be inverted to "if animation is already playing, don't try playing again."