### PR TITLE
Update Jade preprocessor to new Pug name

### DIFF
--- a/components/template/README.md
+++ b/components/template/README.md
@@ -18,7 +18,7 @@ Supports:
 
 - Vanilla HTML (with [basic ES6 templating](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals))
 - [Handlebars.js](https://http://handlebarsjs.com/)
-- [Jade](http://jade-lang.com/)
+- [Pug (formerly Jade)](https://pugjs.org)
 - [mustache.js](https://mustache.github.io/)
 - [Nunjucks](https://mozilla.github.io/nunjucks/)
 


### PR DESCRIPTION
Where it used to say "Jade", it now notes the name  change to "Pug", to avoid confusion!

> Due to a trademark issue, the project name has been changed from “Jade” to “Pug” in conjunction with the release of Pug 2.

(from the [Pug website](https://pugjs.org/api/migration-v2.html))