### PR TITLE
[animation] remove animationIsPlaying = true manual set

### DIFF
--- a/components/animation/index.js
+++ b/components/animation/index.js
@@ -88,8 +88,6 @@ AFRAME.registerComponent('animation', {
     // Stop previous animation.
     this.pauseAnimation();
 
-    if (!this.data.startEvents.length) { this.animationIsPlaying = true; }
-
     // Play animation if no holding event.
     this.removeEventListeners();
     this.addEventListeners();


### PR DESCRIPTION
This line is messing with the logic [here](https://github.com/ngokevin/kframe/blob/a0b696e9b1f7eb45ecc5297f81df33168395b26b/components/animation/index.js#L115). From my testing, after initial `update`, `play` gets called for you. So I think we can rely on that setting `animationIsPlaying = true`.