### PR TITLE
look-at component uses function isCoordinates instead isCoordinate

### DIFF
--- a/components/look-at/index.js
+++ b/components/look-at/index.js
@@ -2,7 +2,7 @@ var debug = AFRAME.utils.debug;
 var coordinates = AFRAME.utils.coordinates;
 
 var warn = debug('components:look-at:warn');
-var isCoordinates = coordinates.isCoordinates;
+var isCoordinates = coordinates.isCoordinate;
 
 delete AFRAME.components['look-at'];
 


### PR DESCRIPTION
I think though the name 'isCoordinates' is being used in developer version, components should follow the stable version.