### PR TITLE
make work with camera entities

### DIFF
--- a/components/look-at/index.js
+++ b/components/look-at/index.js
@@ -2,7 +2,7 @@ var debug = AFRAME.utils.debug;
 var coordinates = AFRAME.utils.coordinates;
 
 var warn = debug('components:look-at:warn');
-var isCoordinates = coordinates.isCoordinate;
+var isCoordinates = coordinates.isCoordinates;
 
 delete AFRAME.components['look-at'];
 
@@ -81,9 +81,19 @@ AFRAME.registerComponent('look-at', {
     // Track target object position. Depends on parent object keeping global transforms up
     // to state with updateMatrixWorld(). In practice, this is handled by the renderer.
     var target3D = this.target3D;
+    var object3D = this.el.object3D;
+    var vector = this.vector;
     if (target3D) {
-      var vector = this.el.object3D.parent.worldToLocal(target3D.getWorldPosition());
-      return this.el.object3D.lookAt(vector);
+      var target = object3D.parent.worldToLocal(target3D.getWorldPosition());
+      if (!!this.el.getObject3D('camera')) {
+        // Flip the vector to -z, looking away from target for camera entities.  When using
+        // lookat from THREE camera objects, this is applied for you, but since the camera is
+        // nested into a Object3D, we need to apply this manually.
+        vector.subVectors(object3D.position, target).add(object3D.position);
+      } else {
+        vector = target;
+      }
+      object3D.lookAt(vector);
     }
   },
 

--- a/components/look-at/package.json
+++ b/components/look-at/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/ngokevin/kframe/tree/look-at#readme",
   "devDependencies": {
-    "aframe": "^0.3.0",
+    "aframe": "^0.5.0",
     "browserify": "^12.0.1",
     "budo": "^7.1.0",
     "shelljs": "^0.6.0",


### PR DESCRIPTION
this is done for you when calling `lookat` on camera objects in three.  Because A-Frame uses a proxy object3D, the correct -z (looking away) vector is not applied.

Also bumps a-frame version.