### PR TITLE
Fix dead link

### DIFF
--- a/components/look-at/README.md
+++ b/components/look-at/README.md
@@ -26,7 +26,7 @@ Install and use by directly including the [browser files](dist):
 <head>
   <title>My A-Frame Scene</title>
   <script src="https://aframe.io/releases/0.4.0/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-look-at-component@^0.2.0/aframe-look-at-component.min.js"></script>
+  <script src="https://unpkg.com/aframe-look-at-component@0.5.1/dist/aframe-look-at-component.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Hitting the old URL, I get `Not found: file "/aframe-look-at-component.min.js" in package aframe-look-at-component@0.2.0`.