### PR TITLE
[look-at] Prevent isCoordinate deprecation warnings

### DIFF
--- a/components/look-at/index.js
+++ b/components/look-at/index.js
@@ -2,7 +2,7 @@ var debug = AFRAME.utils.debug;
 var coordinates = AFRAME.utils.coordinates;
 
 var warn = debug('components:look-at:warn');
-var isCoordinates = coordinates.isCoordinate || coordinates.isCoordinates;
+var isCoordinates = coordinates.isCoordinates || coordinates.isCoordinate;
 
 delete AFRAME.components['look-at'];
 


### PR DESCRIPTION
`isCoordinate` still exists in A-Frame 0.6.0 but with a deprecation warning (causing a wall of warning messages in the console when the `look-at` component is used). This commit uses `isCoordinates` first if it exists and falls back to `isCoordinate` if it doesn't (for A-Frame <0.6.0).