### PR TITLE
Update Unpkg version to 4.2.0

### DIFF
--- a/components/layout/README.md
+++ b/components/layout/README.md
@@ -60,7 +60,7 @@ Install and use by directly including the [browser files](dist):
 <head>
   <title>My A-Frame Scene</title>
   <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-layout-component@4.1.1/dist/aframe-layout-component.min.js"></script>
+  <script src="https://unpkg.com/aframe-layout-component@4.2.0/dist/aframe-layout-component.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Version `4.1.1` no longer works from unpkg, so this updates the unpkg link in the README to [`4.2.0`](https://unpkg.com/aframe-layout-component@4.2.0/dist/aframe-layout-component.min.js)

----

Also, @ngokevin, consider putting a deprecated/obsolete warning on the [npm page for aframe-layout](https://www.npmjs.com/package/aframe-layout), as it may be confusing to other people?