### PR TITLE
Fix MUSTACHE case in getComiler()

### DIFF
--- a/components/template/index.js
+++ b/components/template/index.js
@@ -182,7 +182,7 @@ function getCompiler (type) {
       return compileJadeTemplate;
     }
     case MUSTACHE: {
-      return compileHandlebarsTemplate;
+      return compileMustacheTemplate;
     }
     case NUNJUCKS: {
       return compileNunjucksTemplate;


### PR DESCRIPTION
Case MUSTACHE also call `compileHandlebarsTemplate`, change it to `compileMustacheTemplate`.