### PR TITLE
geometry-merger: Preserve existing material

### DIFF
--- a/components/geometry-merger/index.js
+++ b/components/geometry-merger/index.js
@@ -8,9 +8,8 @@ AFRAME.registerComponent('geometry-merger', {
     var faceIndexStart;
     var self = this;
 
-    this.geometry = new THREE.Geometry();
-    this.mesh = new THREE.Mesh(this.geometry);
-    this.el.setObject3D('mesh', this.mesh);
+    this.mesh = this.el.getOrCreateObject3D('mesh', THREE.Mesh);
+    this.geometry = this.mesh.geometry = new THREE.Geometry();
 
     this.faceIndex = {};  // Keep index of original entity UUID to new face array.
     this.vertexIndex = {};  // Keep index of original entity UUID to vertex array.


### PR DESCRIPTION
This component is great. I tried experimenting with `mergeTo` once and never got anywhere, but `geometry-merger` is doing exactly what I expect. 


Currently, if a `material` component is set prior to the merging, future calls to `setAttribute('material')` will have no effect (apparently updating a material that is no longer in the `object3D`). This PR adjusts it to keep using the existing material, if available. 