### PR TITLE
[layout] add alignment options for box and line layouts

### DIFF
--- a/components/layout/README.md
+++ b/components/layout/README.md
@@ -40,17 +40,18 @@ We move then entire group around while maintaining the layout:
 
 ### Properties
 
-| Property     | Description                                                                                        | Default Value |
-|--------------|----------------------------------------------------------------------------------------------------|---------------|
-| type         | Type of layout. Can be one of `box`, `circle`, `cube`, `dodecahedron`, `line`, `pyramid`.          | `line`        |
-| columns      | Number of columns (for type `box`).                                                                | 1             |
-| margin       | Margin in meters (for type `box`, `line`).                                                         | 1             |
-| marginColumn | Margin in meters just for the columns (for type `box`). Defaults to `margin` value.                | 1             |
-| marginRow    | Margin in meters just for the rows (for type `box`). Defaults to `margin` value.                   | 1             |
-| plane        | Which plane direction for 2D layout. Can be `xy`, `yz`, or `xz` (for type `box`, `circle`, `line`) | `xy`          |
-| radius       | Radius in meters (for type `circle`, `cube`, `dodecahedron`, `pyramid`.                            | 1             |
-| reverse      | Whether to reverse direction of layout.                                                            | false         |
-| angle        | For type `circle`, set this to position items `angle` degrees apart                                | false         |
+| Property     | Description                                                                                         | Default Value |
+|--------------|-----------------------------------------------------------------------------------------------------|---------------|
+| type         | Type of layout. Can be one of `box`, `circle`, `cube`, `dodecahedron`, `line`, `pyramid`.           | `line`        |
+| columns      | Number of columns (for type `box`).                                                                 | 1             |
+| margin       | Margin in meters (for type `box`, `line`).                                                          | 1             |
+| marginColumn | Margin in meters just for the columns (for type `box`). Defaults to `margin` value.                 | 1             |
+| marginRow    | Margin in meters just for the rows (for type `box`). Defaults to `margin` value.                    | 1             |
+| plane        | Which plane direction for 2D layout. Can be `xy`, `yz`, or `xz` (for type `box`, `circle`, `line`)  | `xy`          |
+| radius       | Radius in meters (for type `circle`, `cube`, `dodecahedron`, `pyramid`.                             | 1             |
+| reverse      | Whether to reverse direction of layout.                                                             | false         |
+| angle        | For type `circle`, set this to position items `angle` degrees apart                                 | false         |
+| align        | Alignment of the center of layout (for type `box`, `line`). Can be one of `start`, `center`, `end`. | `start`       |
 
 ### Usage
 

--- a/components/layout/examples/box/index.html
+++ b/components/layout/examples/box/index.html
@@ -18,7 +18,7 @@
                 material="color: #2994B2; shader: flat" scale="1 1 -1">
       </a-entity>
 
-      <a-entity layout="type: box; columns: 4; margin: 4; keepCentered: true" position="0 0 -15">
+      <a-entity layout="type: box; columns: 4; margin: 4" position="0 0 -15">
         <a-entity mixin="cube"></a-entity>
         <a-entity mixin="cube"></a-entity>
         <a-entity mixin="cube"></a-entity>

--- a/components/layout/examples/box/index.html
+++ b/components/layout/examples/box/index.html
@@ -18,7 +18,7 @@
                 material="color: #2994B2; shader: flat" scale="1 1 -1">
       </a-entity>
 
-      <a-entity layout="type: box; columns: 4; margin: 4" position="0 0 -15">
+      <a-entity layout="type: box; columns: 4; margin: 4; keepCentered: true" position="0 0 -15">
         <a-entity mixin="cube"></a-entity>
         <a-entity mixin="cube"></a-entity>
         <a-entity mixin="cube"></a-entity>

--- a/components/layout/examples/line/index.html
+++ b/components/layout/examples/line/index.html
@@ -4,6 +4,7 @@
     <meta name="description" content="One-dimensional layout of boxes"></meta>
     <meta property="og:image" content="https://raw.githubusercontent.com/ngokevin/kframe/master/components/layout/examples/line/preview.png"></meta>
     <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
+    <script src="https://unpkg.com/aframe-entity-generator-component@3.0.1/dist/aframe-entity-generator-component.min.js"></script>
     <script src="../../dist/aframe-layout-component.min.js"></script>
   </head>
   <body>
@@ -11,22 +12,25 @@
       <a-assets>
         <a-mixin id="cube" geometry="primitive: box"
                  material="color: #FFFBE0"></a-mixin>
-        <a-mixin id="secondary" material="color: #FFB400"></a-mixin>
+        <a-mixin id="c1" material="color: #FFB400"></a-mixin>
+        <a-mixin id="c2" material="color: #B4FF00"></a-mixin>
+        <a-mixin id="c3" material="color: #00B4FF"></a-mixin>
       </a-assets>
 
       <a-entity geometry="primitive: sphere; radius: 1000"
                 material="color: #2994B2; shader: flat" scale="1 1 -1">
       </a-entity>
 
-      <a-entity layout="type: line; margin: 5" position="0 0 -15">
-        <a-entity mixin="cube"></a-entity>
-        <a-entity mixin="cube"></a-entity>
-        <a-entity mixin="cube"></a-entity>
-        <a-entity mixin="cube"></a-entity>
-        <a-entity mixin="cube"></a-entity>
-        <a-entity mixin="cube"></a-entity>
-        <a-entity mixin="cube"></a-entity>
-        <a-entity mixin="cube"></a-entity>
+      <a-entity entity-generator="mixin: cube c1; num: 8"
+                layout="type: line; margin: 5; align: start" position="0 5 -15">
+      </a-entity>
+
+      <a-entity entity-generator="mixin: cube c2; num: 9"
+                layout="type: line; margin: 5; align: center" position="0 0 -15">
+      </a-entity>
+
+      <a-entity entity-generator="mixin: cube c3; num: 9"
+                layout="type: line; margin: 5; align: end" position="0 -5 -15">
       </a-entity>
     </a-scene>
 

--- a/components/layout/index.js
+++ b/components/layout/index.js
@@ -14,7 +14,8 @@ AFRAME.registerComponent('layout', {
     reverse: {default: false},
     type: {default: 'line', oneOf: ['box', 'circle', 'cube', 'dodecahedron', 'line',
                                     'pyramid']},
-    fill: {default: true, if: {type: ['circle']}}
+    fill: {default: true, if: {type: ['circle']}},
+    keepCentered: {default: false}
   },
 
   /**
@@ -129,20 +130,23 @@ function getBoxPositions (data, numChildren, marginDefined) {
     marginRow = data.margin;
   }
 
+  var offsetRow = data.keepCentered ? (rows - 1) / 2 : 0;
+  var offsetColumn = data.keepCentered ? (data.columns - 1) / 2 : 0;
+
   for (var row = 0; row < rows; row++) {
     for (var column = 0; column < data.columns; column++) {
       position = [0, 0, 0];
       if (data.plane.indexOf('x') === 0) {
-        position[0] = column * marginColumn;
+        position[0] = (column - offsetColumn) * marginColumn;
       }
       if (data.plane.indexOf('y') === 0) {
-        position[1] = column * marginColumn;
+        position[1] = (column - offsetColumn) * marginColumn;
       }
       if (data.plane.indexOf('y') === 1) {
-        position[1] = row * marginRow;
+        position[1] = (row - offsetRow) * marginRow;
       }
       if (data.plane.indexOf('z') === 1) {
-        position[2] = row * marginRow;
+        position[2] = (row - offsetRow) * marginRow;
       }
       positions.push(position);
     }

--- a/components/layout/index.js
+++ b/components/layout/index.js
@@ -15,7 +15,7 @@ AFRAME.registerComponent('layout', {
     type: {default: 'line', oneOf: ['box', 'circle', 'cube', 'dodecahedron', 'line',
                                     'pyramid']},
     fill: {default: true, if: {type: ['circle']}},
-    keepCentered: {default: false}
+    align: {default: 'end', oneOf: ['start', 'center', 'end']}
   },
 
   /**
@@ -130,8 +130,8 @@ function getBoxPositions (data, numChildren, marginDefined) {
     marginRow = data.margin;
   }
 
-  var offsetRow = data.keepCentered ? (rows - 1) / 2 : 0;
-  var offsetColumn = data.keepCentered ? (data.columns - 1) / 2 : 0;
+  var offsetRow = getOffsetItemIndex(data.align, rows);
+  var offsetColumn = getOffsetItemIndex(data.align, data.columns);
 
   for (var row = 0; row < rows; row++) {
     for (var column = 0; column < data.columns; column++) {
@@ -266,6 +266,23 @@ function getPyramidPositions (data, numChildren) {
   ], data.radius / 2);
 }
 module.exports.getPyramidPositions = getPyramidPositions;
+
+/**
+ * Return the item index in a given list to calculate offsets from
+ *
+ * @param {string} align - One of `'start'`, `'center'`, `'end'`
+ * @param {integer} numItems - Total number of items
+ */
+function getOffsetItemIndex (align, numItems) {
+  switch (align) {
+    case 'start':
+      return numItems - 1;
+    case 'center':
+      return (numItems - 1) / 2;
+    case 'end':
+      return 0;
+  }
+}
 
 /**
  * Multiply all coordinates by a scale factor and add translate.


### PR DESCRIPTION
Fixes #27 via an `alignment` property for `box` and `line` layouts.

The current behaviour is the default and corresponds to `align: end`. The PR adds support for `align: start` and `align: center` modes that align the center of the resulting layout at the start or the center, respectively, of the laid out elements.