### PR TITLE
Adds some version constraints to sample code

### DIFF
--- a/components/aabb-collider/README.md
+++ b/components/aabb-collider/README.md
@@ -46,7 +46,7 @@ Install and use by directly including the [browser files](dist):
 <head>
   <title>My A-Frame Scene</title>
   <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-aabb-collider-component/dist/aframe-aabb-collider-component.min.js"></script>
+  <script src="https://unpkg.com/aframe-aabb-collider-component@^2.2.1/dist/aframe-aabb-collider-component.min.js"></script>
 </head>
 
 <body>

--- a/components/animation-timeline/README.md
+++ b/components/animation-timeline/README.md
@@ -185,8 +185,8 @@ Install and use by directly including the [browser files](dist):
 <head>
   <title>My A-Frame Scene</title>
   <script src="https://aframe.io/releases/0.8.0/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-animation-component@4.0.0-beta8/dist/aframe-animation-timeline-component.min.js"></script>
-  <script src="https://unpkg.com/aframe-animation-timeline-component/dist/aframe-animation-timeline-component.min.js"></script>
+  <script src="https://unpkg.com/aframe-animation-component@^4.1.1/dist/aframe-animation-timeline-component.min.js"></script>
+  <script src="https://unpkg.com/aframe-animation-timeline-component@^1.3.1/dist/aframe-animation-timeline-component.min.js"></script>
 </head>
 
 <body>

--- a/components/animation/README.md
+++ b/components/animation/README.md
@@ -95,7 +95,7 @@ Install and use by directly including the [browser files](dist):
 <head>
   <title>My A-Frame Scene</title>
   <script src="https://aframe.io/releases/0.8.0/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-animation-component@4.0.0/dist/aframe-animation-component.min.js"></script>
+  <script src="https://unpkg.com/aframe-animation-component@^4.1.2/dist/aframe-animation-component.min.js"></script>
 </head>
 
 <body>

--- a/components/atlas-uvs/README.md
+++ b/components/atlas-uvs/README.md
@@ -27,7 +27,7 @@ Install and use by directly including the [browser files](dist):
 <head>
   <title>My A-Frame Scene</title>
   <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-atlas-uvs-component/dist/aframe-atlas-uvs-component.min.js"></script>
+  <script src="https://unpkg.com/aframe-atlas-uvs-component@^1.0.0/dist/aframe-atlas-uvs-component.min.js"></script>
 </head>
 
 <body>

--- a/components/fps-counter/README.md
+++ b/components/fps-counter/README.md
@@ -26,7 +26,7 @@ Install and use by directly including the [browser files](dist):
 <head>
   <title>My A-Frame Scene</title>
   <script src="https://aframe.io/releases/0.7.1/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-fps-counter-component/dist/aframe-fps-counter-component.min.js"></script>
+  <script src="https://unpkg.com/aframe-fps-counter-component@^1.0.1/dist/aframe-fps-counter-component.min.js"></script>
 </head>
 
 <body>

--- a/components/mountain/README.md
+++ b/components/mountain/README.md
@@ -26,7 +26,7 @@ Install and use by directly including the [browser files](dist):
 <head>
   <title>My A-Frame Scene</title>
   <script src="https://aframe.io/releases/0.3.0/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-mountain-component@^0.3.2/aframe-mountain-component.min.js"></script>
+  <script src="https://unpkg.com/aframe-mountain-component@^0.3.3/aframe-mountain-component.min.js"></script>
 </head>
 
 <body>

--- a/components/state/README.md
+++ b/components/state/README.md
@@ -226,7 +226,7 @@ Install and use by directly including the [browser files](dist):
 <head>
   <title>My A-Frame Scene</title>
   <script src="https://aframe.io/releases/0.8.0/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-state-component/dist/aframe-state-component.min.js"></script>
+  <script src="https://unpkg.com/aframe-state-component@^3.0.0/dist/aframe-state-component.min.js"></script>
   <script>
     AFRAME.registerState({
       initialState: {

--- a/components/sun-sky/README.md
+++ b/components/sun-sky/README.md
@@ -11,8 +11,8 @@ Install and use by directly including the [browser files](dist):
 ```html
 <head>
   <title>My A-Frame Scene</title>
-  <script src="https://aframe.io/releases/0.3.0/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-sun-sky-component@^3.0.0/dist/aframe-sun-sky-component.min.js"></script>
+  <script src="https://aframe.io/releases/0.8.0/aframe.min.js"></script>
+  <script src="https://unpkg.com/aframe-sun-sky-component@^3.0.3/dist/aframe-sun-sky-component.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
My app stopped working this morning until I added a constraint on the version of aframe-state-component, so this should help others avoid that issue, when there are breaking changes.

I haven't checked every example to verify that the component version and aframe version are compatible.

I created this contribution and have the right to submit it to the Project. I understand this contribution is public and may be redistributed as open source software. I am granting the Project a copyright license to use, modify and distribute my contribution.
