### PR TITLE
Upgrade Orbit Controls NPM version and fix minAzimuthAngle and maxAzimuthAngle

### DIFF
--- a/components/orbit-controls/README.md
+++ b/components/orbit-controls/README.md
@@ -61,7 +61,7 @@ Install and use by directly including the [browser files](dist):
 <head>
   <title>My A-Frame Scene</title>
   <script src="https://aframe.io/releases/0.8.2/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-orbit-controls@1.0.0/dist/aframe-orbit-controls.min.js"></script>
+  <script src="https://unpkg.com/aframe-orbit-controls@1.2.0/dist/aframe-orbit-controls.min.js"></script>
   <script src="https://unpkg.com/aframe-supercraft-loader@1.1.3/dist/aframe-supercraft-loader.js"></script>
 </head>
 

--- a/components/orbit-controls/index.js
+++ b/components/orbit-controls/index.js
@@ -87,9 +87,11 @@ AFRAME.registerComponent('orbit-controls', {
     controls.enableZoom = data.enableZoom;
     controls.keyPanSpeed = data.keyPanSpeed;
     controls.maxPolarAngle = THREE.Math.degToRad(data.maxPolarAngle);
+    controls.maxAzimuthAngle = THREE.Math.degToRad(data.maxAzimuthAngle);
     controls.maxDistance = data.maxDistance;
     controls.minDistance = data.minDistance;
     controls.minPolarAngle = THREE.Math.degToRad(data.minPolarAngle);
+    controls.minAzimuthAngle = THREE.Math.degToRad(data.minAzimuthAngle);
     controls.minZoom = data.minZoom;
     controls.panSpeed = data.panSpeed;
     controls.rotateSpeed = data.rotateSpeed;


### PR DESCRIPTION
This pull request is specifically for the Orbit Controls component. It includes:

1. Upgrades the ReadMe example to include the most recent NPM js version
2. Fixed bug around minAzimuthAngle and maxAzimuthAngle where the controls were not being defined properly.

This was tested and is working with Aframe 0.8.2 on my end. 